### PR TITLE
Use command line parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,14 @@
 
 ### Installation
 - Install Microsoft Terminal from Microsoft Store.
-- Create `wt.reg` file, paste code below and replace `USERNAME` with your current username.
+- Create `wt.reg` file, paste code below, replace `USERNAME` with your current username, and replace `PROFILENAME` with the name of the profile you want to open.
 ```sh
 Windows Registry Editor Version 5.00
 
-[HKEY_CLASSES_ROOT\Directory\Background\shell\wt]
-@="Open Terminal Here"
+[HKEY_CLASSES_ROOT\Directory\Background\shell\wt.PROFILENAME]
+@="Open Terminal (PROFILENAME) Here"
 
-[HKEY_CLASSES_ROOT\Directory\Background\shell\wt\command]
-@="C:\\Users\\USERNAME\\AppData\\Local\\Microsoft\\WindowsApps\\wt.exe"
+[HKEY_CLASSES_ROOT\Directory\Background\shell\wt.PROFILENAME\command]
+@="C:\\Users\\USERNAME\\AppData\\Local\\Microsoft\\WindowsApps\\wt.exe new-tab -d . -p \"PROFILENAME\""
 ```
 - Add `wt.reg` to registry
-- Open terminal settings panel
-
-![Settings](https://i.imgur.com/Mg5gz2x.png)
-
-- Add line below to each profile, to make terminal open in current directory
-```sh
-"startingDirectory": "."
-```

--- a/wt.reg
+++ b/wt.reg
@@ -1,7 +1,7 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CLASSES_ROOT\Directory\Background\shell\wt]
-@="Open Terminal Here"
+[HKEY_CLASSES_ROOT\Directory\Background\shell\wt.PROFILENAME]
+@="Open Terminal (PROFILENAME) Here"
 
-[HKEY_CLASSES_ROOT\Directory\Background\shell\wt\command]
-@="C:\\Users\\USERNAME\\AppData\\Local\\Microsoft\\WindowsApps\\wt.exe"
+[HKEY_CLASSES_ROOT\Directory\Background\shell\wt.PROFILENAME\command]
+@="C:\\Users\\USERNAME\\AppData\\Local\\Microsoft\\WindowsApps\\wt.exe new-tab -d . -p \"PROFILENAME\""


### PR DESCRIPTION
As of the release of v0.9.433.0, it's now possible to use command line parameters to define a starting directory (This means you no longer need to overwrite the `startingDirectory` property in `profiles.json`), and a profile to open.

This will work for multiple profiles, you just need to replace `PROFILENAME` everywhere in `wt.reg` with the name of the profile you want to open.
![image](https://user-images.githubusercontent.com/8045497/74575070-bc11c480-4fd9-11ea-936d-2f5b3dc8381e.png)

